### PR TITLE
Ref/navbar modular

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,6 @@ import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 import { Container } from "semantic-ui-react";
 
-import "./media-styles.css";
 import Views from "./views";
 import NavBar from "./components/NavBar";
 

--- a/src/components/Logo.js
+++ b/src/components/Logo.js
@@ -2,19 +2,24 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Image, Button } from "semantic-ui-react";
 
-import logo from "../../media/logo.jpg";
-
 /**
  * spreads all props into SUIR Image
  * @param {*} props
  * @param {string} props.size "mini"
- * @param {string} props.src src/media/logo.jpg
+ * @param {string} props.logoImage loaded image file
  * @param {*} props.style boxShadow fitting "mini" size
  */
-export const LogoImage = props => <Image {...props} />;
+export const LogoImage = props => {
+	const { logoImage, ...otherProps } = props;
+
+	return <Image {...otherProps} src={logoImage} />;
+};
+
+LogoImage.propTypes = {
+	logoImage: PropTypes.string.isRequired,
+};
 
 LogoImage.defaultProps = {
-	src: logo,
 	size: "mini",
 	style: { boxShadow: "2px 2px 3px 1px rgba(0,0,0,0.4)" },
 };
@@ -25,18 +30,18 @@ LogoImage.defaultProps = {
  * @param {string} props.size "mini"
  * @param {boolean} props.compact true
  * @param {boolean} props.borderless true
+ * @param {string} props.logoImage loaded image file
  * @param {*} props.content <LogoImage>
  */
-export const LogoButton = props => (
-	// relax warning: Received `true` for a non-boolean attribute
-	<Button
-		{...props}
-		mobile={props.mobile.toString()}
-		borderless={props.borderless.toString()}
-	>
-		<LogoImage />
-	</Button>
-);
+export const LogoButton = props => {
+	const { logoImage, ...buttonProps } = props;
+
+	return (
+		<Button {...buttonProps}>
+			<LogoImage logoImage={logoImage} />
+		</Button>
+	);
+};
 
 // TODO: why doesnt <Button {...props} content/children={LogoImage} /> work?
 // only if content={<LogoImage />} or as explicit child
@@ -48,7 +53,7 @@ LogoButton.propTypes = {
 LogoButton.defaultProps = {
 	size: "mini",
 	compact: true,
-	borderless: true,
+	borderless: "true",
 };
 
 /**
@@ -56,16 +61,25 @@ LogoButton.defaultProps = {
  * - spreads all props
  * @param {*} props
  * @param props.mobile true: <LogoButton>, false: <LogoImage>
+ * @param props.logoImage loaded image file, default: require("src/media/logo.jpg")
  */
-const Logo = props =>
-	props.mobile ? <LogoButton {...props} /> : <LogoImage {...props} />;
+const Logo = props => {
+	const { mobile, ...componentProps } = props;
+
+	return mobile ? (
+		<LogoButton {...componentProps} />
+	) : (
+		<LogoImage {...componentProps} />
+	);
+};
 
 Logo.propTypes = {
 	mobile: PropTypes.bool,
+	logoImage: PropTypes.string.isRequired,
 };
 
 Logo.defaultProps = {
-	mobile: false,
+	logoImage: require("../media/logo.jpg"),
 };
 
 Logo.Image = LogoImage;

--- a/src/components/NavBar/Logo.js
+++ b/src/components/NavBar/Logo.js
@@ -8,7 +8,7 @@ import logo from "../../media/logo.jpg";
  * spreads all props into SUIR Image
  * @param {*} props
  * @param {string} props.size "mini"
- * @param {string} props.src media/logo.jpg
+ * @param {string} props.src src/media/logo.jpg
  * @param {*} props.style boxShadow fitting "mini" size
  */
 export const LogoImage = props => <Image {...props} />;
@@ -28,7 +28,12 @@ LogoImage.defaultProps = {
  * @param {*} props.content <LogoImage>
  */
 export const LogoButton = props => (
-	<Button {...props}>
+	// relax warning: Received `true` for a non-boolean attribute
+	<Button
+		{...props}
+		mobile={props.mobile.toString()}
+		borderless={props.borderless.toString()}
+	>
 		<LogoImage />
 	</Button>
 );
@@ -55,11 +60,14 @@ LogoButton.defaultProps = {
 const Logo = props =>
 	props.mobile ? <LogoButton {...props} /> : <LogoImage {...props} />;
 
-Logo.Image = LogoImage;
-Logo.Button = LogoButton;
-
 Logo.propTypes = {
 	mobile: PropTypes.bool,
 };
 
+Logo.defaultProps = {
+	mobile: false,
+};
+
+Logo.Image = LogoImage;
+Logo.Button = LogoButton;
 export default Logo;

--- a/src/components/NavBar/Logo.js
+++ b/src/components/NavBar/Logo.js
@@ -1,0 +1,65 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Image, Button } from "semantic-ui-react";
+
+import logo from "../../media/logo.jpg";
+
+/**
+ * spreads all props into SUIR Image
+ * @param {*} props
+ * @param {string} props.size "mini"
+ * @param {string} props.src media/logo.jpg
+ * @param {*} props.style boxShadow fitting "mini" size
+ */
+export const LogoImage = props => <Image {...props} />;
+
+LogoImage.defaultProps = {
+	src: logo,
+	size: "mini",
+	style: { boxShadow: "2px 2px 3px 1px rgba(0,0,0,0.4)" },
+};
+
+/**
+ * spreads all props into SUIR Button
+ * @param {*} props.onClick
+ * @param {string} props.size "mini"
+ * @param {boolean} props.compact true
+ * @param {boolean} props.borderless true
+ * @param {*} props.content <LogoImage>
+ */
+export const LogoButton = props => (
+	<Button {...props}>
+		<LogoImage />
+	</Button>
+);
+
+// TODO: why doesnt <Button {...props} content/children={LogoImage} /> work?
+// only if content={<LogoImage />} or as explicit child
+
+LogoButton.propTypes = {
+	onClick: PropTypes.func.isRequired,
+};
+
+LogoButton.defaultProps = {
+	size: "mini",
+	compact: true,
+	borderless: true,
+};
+
+/**
+ * Responsive Logo
+ * - spreads all props
+ * @param {*} props
+ * @param props.mobile true: <LogoButton>, false: <LogoImage>
+ */
+const Logo = props =>
+	props.mobile ? <LogoButton {...props} /> : <LogoImage {...props} />;
+
+Logo.Image = LogoImage;
+Logo.Button = LogoButton;
+
+Logo.propTypes = {
+	mobile: PropTypes.bool,
+};
+
+export default Logo;

--- a/src/components/NavBar/MobileNavBar.js
+++ b/src/components/NavBar/MobileNavBar.js
@@ -6,7 +6,7 @@ import navBarPropTypes from "./prop-types";
 
 /**
  * Responsive Mobile NavBar
- * - only renders at SUIR Responsive.onlyMobile.maxWidth
+ * - only renders up to SUIR Responsive.onlyMobile.maxWidth
  * - mobile links menu overlays content when activated
  * - links menu extends from bottom of nav bar
  *

--- a/src/components/NavBar/MobileNavBar.js
+++ b/src/components/NavBar/MobileNavBar.js
@@ -1,0 +1,83 @@
+import React, { Component, createRef } from "react";
+import { Ref, Menu, Sidebar, Responsive } from "semantic-ui-react";
+
+import NavMenuLink from "./NavMenuLink";
+import navBarPropTypes from "./prop-types";
+
+/**
+ * Responsive Mobile NavBar
+ * - only renders at SUIR Responsive.onlyMobile.maxWidth
+ * - mobile links menu overlays content when activated
+ * - links menu extends from bottom of nav bar
+ *
+ * controls:
+ * - Logo click: toggle
+ * - content area click: close
+ * - NavMenuLink click: close
+ *
+ * @param {*} props
+ * @param {*} content alias for children
+ * @param {*} children content area below nav
+ * @param {*} links [{ name, path }] for menu links
+ * @param {*} Logo Logo component menu controlling button
+ */
+class MobileNavBar extends Component {
+	static propTypes = navBarPropTypes;
+
+	state = {
+		menuOpen: false,
+	};
+
+	// for closing the menu if content area is clicked
+	contentRef = createRef();
+
+	closeMenu = () => this.setState({ menuOpen: false });
+
+	toggleMenu = () => this.setState(state => ({ menuOpen: !state.menuOpen }));
+
+	render = () => {
+		const { content, children, links, Logo } = this.props;
+		const { menuOpen } = this.state;
+
+		return (
+			<Responsive maxWidth={Responsive.onlyMobile.maxWidth}>
+				{/* nav */}
+				<Menu as="nav" size="tiny" widths="1">
+					<Menu.Item>
+						<Logo mobile onClick={this.toggleMenu} />
+					</Menu.Item>
+				</Menu>
+
+				<Sidebar.Pushable>
+					{/* links menu */}
+					<Sidebar
+						as={Menu}
+						vertical
+						direction="top"
+						animation="overlay"
+						// external click target (content area) that closes the menu
+						target={this.contentRef}
+						visible={menuOpen}
+						onHide={this.closeMenu}
+						style={{ textAlign: "center" }}
+					>
+						{links.map(link => (
+							<NavMenuLink
+								key={`navlink-${link.name}`}
+								onNavigate={this.closeMenu}
+								{...link}
+							/>
+						))}
+					</Sidebar>
+
+					{/* content area (links menu will overlay) */}
+					<Ref innerRef={this.contentRef}>
+						<Sidebar.Pusher content={content || children} />
+					</Ref>
+				</Sidebar.Pushable>
+			</Responsive>
+		);
+	};
+}
+
+export default MobileNavBar;

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import Logo from "./Logo";
+import Logo from "../Logo";
 import "./media-styles.css";
 import MobileNavBar from "./MobileNavBar";
 import navBarPropTypes from "./prop-types";

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -1,118 +1,35 @@
-import React, { Component, createRef } from "react";
-import PropTypes from "prop-types";
-import { Ref, Menu, Sidebar, Responsive } from "semantic-ui-react";
+import React from "react";
 
 import Logo from "./Logo";
-import NavMenuLink from "./NavMenuLink";
+import "./media-styles.css";
+import MobileNavBar from "./MobileNavBar";
+import navBarPropTypes from "./prop-types";
+import StandardNavBar from "./StandardNavBar";
 
-const propTypes = {
-	children: PropTypes.node.isRequired,
-	links: PropTypes.arrayOf(
-		PropTypes.shape({
-			name: PropTypes.string.isRequired,
-			path: PropTypes.string.isRequired,
-		}),
-	).isRequired,
+/**
+ * Responsive NavBar
+ * - only renders NavBar.Mobile up to SUIR Responsive.onlyMobile.maxWidth
+ * - renders NavBar.Standard for widths above SUIR Responsive.onlyTablet.minWidth
+ * 
+ * @param {*} props spread into NavBar.Mobile and NavBar.Standard
+ * @param {*} content alias for children
+ * @param {*} children content area below nav
+ * @param {*} links [{ name, path }] for menu links
+ * @param {*} Logo Logo component menu controlling button
+ */
+const NavBar = props => (
+  <>
+    <MobileNavBar {...props} />
+    <StandardNavBar {...props} />
+  </>
+);
+
+NavBar.propTypes = navBarPropTypes.content;
+
+NavBar.defaultProps = {
+	Logo,
 };
 
-class NavBar extends Component {
-	state = {
-		mobileMenuOpen: false,
-	};
-
-	// for closing the menu if content area is clicked
-	contentRef = createRef();
-
-	closeMobileMenu = () => this.setState({ mobileMenuOpen: false });
-
-	toggleMobileMenu = () =>
-		this.setState(state => ({ mobileMenuOpen: !state.mobileMenuOpen }));
-
-	renderMobile = () => {
-		const { mobileMenuOpen } = this.state;
-		const { links, children } = this.props;
-
-		/**
-		 * mobile menu overlays content
-		 *
-		 * controls:
-		 * - logo click: toggle
-		 * - content area click: close
-		 * - mobile menu item (link) click: close
-		 */
-
-		return (
-			<>
-				<Menu as="nav" size="tiny" widths="1">
-					<Menu.Item>
-						<Logo mobile onClick={this.toggleMobileMenu} />
-					</Menu.Item>
-				</Menu>
-				<Sidebar.Pushable>
-					{/* mobile menu */}
-					<Sidebar
-						as={Menu}
-						vertical
-						direction="top"
-						animation="overlay"
-						// external click target (content area) that closes the menu
-						target={this.contentRef}
-						visible={mobileMenuOpen}
-						onHide={this.closeMobileMenu}
-						style={{ textAlign: "center" }}
-					>
-						{links.map(link => (
-							<NavMenuLink
-								key={`navlink-${link.name}`}
-								onNavigate={this.closeMobileMenu}
-								{...link}
-							/>
-						))}
-					</Sidebar>
-
-					{/* content area (sidebar will overlay) */}
-					<Ref innerRef={this.contentRef}>
-						<Sidebar.Pusher>{children}</Sidebar.Pusher>
-					</Ref>
-				</Sidebar.Pushable>
-			</>
-		);
-	};
-
-	renderStandard = () => {
-		const { links, children } = this.props;
-
-		return (
-			<>
-				<Menu as="nav" fluid borderless>
-					<Menu.Menu widths={links.length} position="left">
-						{links.map(link => (
-							<NavMenuLink key={`navlink-${link.name}`} {...link} />
-						))}
-					</Menu.Menu>
-					<Menu.Item position="right">
-						<Logo size="small" />
-					</Menu.Item>
-				</Menu>
-				{children}
-			</>
-		);
-	};
-
-	render = () => (
-		<>
-			<Responsive
-				children={this.renderMobile()}
-				maxWidth={Responsive.onlyMobile.maxWidth}
-			/>
-			<Responsive
-				children={this.renderStandard()}
-				minWidth={Responsive.onlyTablet.minWidth}
-			/>
-		</>
-	);
-}
-
-NavBar.propTypes = propTypes;
-
+NavBar.Mobile = MobileNavBar;
+NavBar.Standard = StandardNavBar;
 export default NavBar;

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -1,18 +1,9 @@
 import React, { Component, createRef } from "react";
 import PropTypes from "prop-types";
-import { Link } from "react-router-dom";
-import {
-	Ref,
-	Menu,
-	Image,
-	Button,
-	Sidebar,
-	Responsive,
-} from "semantic-ui-react";
+import { Ref, Menu, Sidebar, Responsive } from "semantic-ui-react";
 
-import logo from "../media/logo.jpg";
-
-const rootDiv = document.querySelector("#root");
+import Logo from "./Logo";
+import NavMenuLink from "./NavMenuLink";
 
 const propTypes = {
 	children: PropTypes.node.isRequired,
@@ -22,39 +13,6 @@ const propTypes = {
 			path: PropTypes.string.isRequired,
 		}),
 	).isRequired,
-};
-
-const NavMenuLink = props => (
-	<Menu.Item
-		as={Link}
-		to={props.path}
-		content={props.name}
-		onClick={props.onNavigate}
-	/>
-);
-
-const Logo = props => {
-	const { mobile, onClick } = props;
-
-	const LogoImage = (
-		<Image
-			size="mini"
-			src={logo}
-			style={{ boxShadow: "2px 2px 3px 1px rgba(0,0,0,0.4)" }}
-		/>
-	);
-
-	return mobile ? (
-		<Button
-			size="mini"
-			borderless
-			compact
-			onClick={onClick}
-			content={LogoImage}
-		/>
-	) : (
-		LogoImage
-	);
 };
 
 class NavBar extends Component {
@@ -69,15 +27,6 @@ class NavBar extends Component {
 
 	toggleMobileMenu = () =>
 		this.setState(state => ({ mobileMenuOpen: !state.mobileMenuOpen }));
-
-	// toggles padding if screen transitions in width
-	setRootDivPadding = (_, data) => {
-		const { getWidth } = data;
-		rootDiv.style =
-			getWidth() > Responsive.onlyMobile.maxWidth
-				? "padding: 30px 50px 0px 50px" // > mobile max add padding
-				: ""; // <= mobile max remove padding
-	};
 
 	renderMobile = () => {
 		const { mobileMenuOpen } = this.state;
@@ -153,12 +102,10 @@ class NavBar extends Component {
 	render = () => (
 		<>
 			<Responsive
-				onUpdate={this.setRootDivPadding}
 				children={this.renderMobile()}
 				maxWidth={Responsive.onlyMobile.maxWidth}
 			/>
 			<Responsive
-				onUpdate={this.setRootDivPadding}
 				children={this.renderStandard()}
 				minWidth={Responsive.onlyTablet.minWidth}
 			/>

--- a/src/components/NavBar/NavMenuLink.js
+++ b/src/components/NavBar/NavMenuLink.js
@@ -1,0 +1,28 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+import { Menu } from "semantic-ui-react";
+
+/**
+ * NavBar SUIR Menu as React Router Link
+ * @param {*} props
+ * @param {string} props.path Link to
+ * @param {string} props.name Link content
+ * @param {func} props.onNavigate onClick handler
+ */
+const NavMenuLink = props => (
+	<Menu.Item
+		as={Link}
+		to={props.path}
+		content={props.name}
+		onClick={props.onNavigate}
+	/>
+);
+
+NavMenuLink.propTypes = {
+	onClick: PropTypes.func,
+	name: PropTypes.string.isRequired,
+	path: PropTypes.string.isRequired,
+};
+
+export default NavMenuLink;

--- a/src/components/NavBar/StandardNavBar.js
+++ b/src/components/NavBar/StandardNavBar.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { Menu, Responsive } from "semantic-ui-react";
+
+import NavMenuLink from "./NavMenuLink";
+import navBarPropTypes from "./prop-types";
+
+/**
+ * Responsive Standard NavBar
+ * - renders at widths above SUIR Responsive.onlyTablet.minWidth
+ * 
+ * @param {*} props
+ * @param {*} content alias for children
+ * @param {*} children content area below nav
+ * @param {*} links [{ name, path }] for menu links
+ * @param {*} Logo Logo component menu controlling button 
+ */
+const StandardNavBar = props => {
+	const { links, content, children, Logo } = props;
+
+	return (
+		<Responsive minWidth={Responsive.onlyTablet.minWidth}>
+			{/* nav */}
+			<Menu as="nav" fluid borderless size="huge">
+				<Menu.Menu widths={links.length} position="left">
+					{links.map(link => (
+						<NavMenuLink key={`navlink-${link.name}`} {...link} />
+					))}
+				</Menu.Menu>
+				<Menu.Item position="right">
+					<Logo />
+				</Menu.Item>
+			</Menu>
+
+      {/* content area */}
+			{content || children}
+		</Responsive>
+	);
+};
+
+StandardNavBar.propTypes = navBarPropTypes;
+
+export default StandardNavBar;

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -1,0 +1,7 @@
+import Logo from "./Logo";
+import NavBar from "./NavBar";
+import NavMenuLink from "./NavMenuLink";
+
+export { Logo, NavMenuLink };
+
+export default NavBar;

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -1,7 +1,5 @@
-import Logo from "./Logo";
 import NavBar from "./NavBar";
 import NavMenuLink from "./NavMenuLink";
 
-export { Logo, NavMenuLink };
-
+NavBar.MenuLink = NavMenuLink;
 export default NavBar;

--- a/src/components/NavBar/media-styles.css
+++ b/src/components/NavBar/media-styles.css
@@ -1,4 +1,3 @@
-
 @media only screen and (max-width: 800px) {
   /* mobile */
 }

--- a/src/components/NavBar/prop-types.js
+++ b/src/components/NavBar/prop-types.js
@@ -1,0 +1,15 @@
+import PropTypes from "prop-types";
+
+import optionalProp from "../../utils/optional-prop";
+
+export default {
+	Logo: PropTypes.func.isRequired,
+	links: PropTypes.arrayOf(
+		PropTypes.shape({
+			name: PropTypes.string.isRequired,
+			path: PropTypes.string.isRequired,
+		}),
+	).isRequired,
+	children: optionalProp.ifOtherPropDefined("content"),
+	content: optionalProp.ifOtherPropDefined("children"),
+};

--- a/src/utils/optional-prop.js
+++ b/src/utils/optional-prop.js
@@ -1,0 +1,17 @@
+const optionalProp = {};
+
+optionalProp.ifOtherPropDefined = otherPropName => (
+	props,
+	propName,
+	componentName,
+) => {
+  const errorMessage = `Invalid props: [${componentName}] requires either [${propName}] or ${otherPropName} to be defined.`;
+  
+	if (
+		[props[propName], props[otherPropName]].every(value => value === undefined)
+	) {
+		return new Error(errorMessage);
+	}
+};
+
+export default optionalProp;


### PR DESCRIPTION
## split NavBar into separate modules
- NavBar, NavBar.Mobile, NavBar.Standard
  - MobileNavBar
  - StandardNavBar
- Logo, Logo.Image, Logo.Button
  - LogoImage
  - LogoButton
- NavMenuLink

# tablet +
<img width="1277" alt="Screen Shot 2019-05-18 at 2 14 13 AM" src="https://user-images.githubusercontent.com/25523682/57965935-504ede00-7919-11e9-8048-7b6ac90dfe5b.png">

# mobile
<img width="400" alt="Screen Shot 2019-05-18 at 2 58 55 AM" src="https://user-images.githubusercontent.com/25523682/57965942-62308100-7919-11e9-8cab-1772930088a4.png">

<img width="404" alt="Screen Shot 2019-05-18 at 2 59 07 AM" src="https://user-images.githubusercontent.com/25523682/57965944-665c9e80-7919-11e9-9509-27579189852f.png">

