### PR TITLE
Ref/landing styling

### DIFF
--- a/src/components/CourseCard.js
+++ b/src/components/CourseCard.js
@@ -1,13 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import {
-	Card,
-	Icon,
-	List,
-	Popup,
-	Button,
-	Header,
-} from "semantic-ui-react";
+import { Card, Icon, List, Popup, Button, Header } from "semantic-ui-react";
 
 import { courseType } from "../utils/prop-types";
 
@@ -70,13 +63,12 @@ const CourseCard = props => {
 			<Card.Content extra>
 				<Button.Group fluid>
 					<Button
-						color="blue"
 						rounded
-						size="large"
 						as={Link}
+						size="large"
 						content="Register Now"
 						to={`/register?courseID=${id}`}
-						// style={{ backgroundColor: "var(--primary-light)", color: "white"}}
+						style={{ backgroundColor: "var(--dark-blue)", color: "white" }}
 					/>
 					<Button.Or />
 					<Button

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -16,9 +16,9 @@ const Footer = props => {
 	const { links } = props;
 
 	return (
-			<Menu size="large" style={{ bottom: "0px"}}>
+			<Menu size="large" borderless>
 				{links.map(link => (
-					<MenuLink {...link} />
+					<MenuLink key={`footer-${link.name}`} {...link} />
 				))}
 			</Menu>
 	);

--- a/src/global.css
+++ b/src/global.css
@@ -14,6 +14,12 @@ body {
 
 h1 {
 	text-transform: uppercase !important;
+	text-shadow: 4px 4px 0px rgba(0, 0, 0, 0.2) !important;
+}
+
+h2,
+h3 {
+	text-shadow: 3px 3px 0px rgba(0, 0, 0, 0.2) !important;
 }
 
 @media only screen and (max-width: 1023px) {

--- a/src/variables.css
+++ b/src/variables.css
@@ -39,7 +39,7 @@
 		)
 		fixed;
 
-	--desktop-h1: 5rem;
+	--desktop-h1: 4.75rem;
 	--desktop-h2: 3rem;
 	--desktop-h3: 2rem;
 }

--- a/src/views/LandingView/Banner.js
+++ b/src/views/LandingView/Banner.js
@@ -28,18 +28,13 @@ const Banner = props => {
 				/>
 			)}
 			{/* site name - uppercased by global CSS */}
-			<Header
-				as="h1"
-				inverted
-				content="Princeton Groundwater"
-				style={{ textShadow: "4px 4px 0px rgba(0,0,0,0.2)" }}
-			/>
+			<Header as="h1" inverted content="Princeton Groundwater" />
 			{/* banner phrase */}
 			<Header
 				as="h3"
 				inverted
 				content={bannerPhrase}
-				style={{ textShadow: "3px 3px 0px rgba(0,0,0,0.2)" }}
+				style={{ fontStyle: "oblique" }}
 			/>
 		</Container>
 	);

--- a/src/views/LandingView/ValuePropositions.js
+++ b/src/views/LandingView/ValuePropositions.js
@@ -55,7 +55,7 @@ const ValuePropositions = props => {
 		<ValuePropCard {...cardData} />
 	));
 
-	return <Card.Group centered stackable content={cards} />;
+	return <Card.Group centered stackable itemsPerRow="2" content={cards} />;
 };
 
 export default ValuePropositions;

--- a/src/views/LandingView/index.js
+++ b/src/views/LandingView/index.js
@@ -26,25 +26,48 @@ const LandingView = props => {
 					<Banner {...viewData} mobile={mobile} />
 				</Grid.Column>
 			</Grid.Row>
-			<Grid.Row>
-				<Grid.Column computer="10" tablet="10" mobile="16">
-					{/* intro video */}
-					<Embed defaultActive autoplay={false} source="youtube" id={viewData.videoID} />
+      <Divider section />
+
+    {/* MOBILE-TABLET: video + value props */}
+			<Grid.Row columns="equal" only="mobile tablet">
+				<Grid.Column tablet="10" mobile="16">
+					<Embed
+						defaultActive
+						autoplay={false}
+						source="youtube"
+						id={viewData.videoID}
+					/>
 				</Grid.Column>
 			</Grid.Row>
 
-			<Grid.Row>
-				<Grid.Column computer="16" tablet="16" mobile="14">
+			<Grid.Row only="mobile tablet">
+				<Grid.Column tablet="16" mobile="14">
+					<ValuePropositions />
+				</Grid.Column>
+			</Grid.Row>
+
+    {/* DESKTOP+: video + value props */}
+			<Grid.Row columns="equal" only="computer">
+				<Grid.Column width="6" verticalAlign="middle">
+					{/* intro video */}
+					<Embed
+						defaultActive
+						autoplay={false}
+						source="youtube"
+						id={viewData.videoID}
+					/>
+				</Grid.Column>
+				<Grid.Column width="10">
 					<ValuePropositions />
 				</Grid.Column>
 			</Grid.Row>
 
 			<Grid.Row>
-				<Header as="h1" content="Upcoming Courses" inverted />
+				<Header as="h2" content="Upcoming Courses" inverted />
 			</Grid.Row>
 
 			<Grid.Row>
-				<Grid.Column computer="12" tablet="16" mobile="15">
+				<Grid.Column computer="16" tablet="16" mobile="15">
 					<UpcomingCourses {...viewData} />
 				</Grid.Column>
 			</Grid.Row>

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -7,7 +7,7 @@ import RegistrationView from "./RegistrationView";
 import siteLinks, { linksAsList } from "./site-links";
 
 const Views = () => (
-	<Container style={{ paddingTop: "20px", paddingBottom: "100px" }}>
+	<Container style={{ paddingTop: "20px", paddingBottom: "20px" }}>
 		<Switch>
 			<Route exact path="/" component={LandingView} />
       <Route path="/register/:courseID?" component={RegistrationView} />


### PR DESCRIPTION
adjusted styling to be more compact on desktop

# Desktop

<img width="1280" alt="Screen Shot 2019-05-23 at 4 08 35 PM" src="https://user-images.githubusercontent.com/25523682/58282981-324c0800-7d75-11e9-9a7e-8a4b721ae8e9.png">
<img width="1280" alt="Screen Shot 2019-05-23 at 4 08 53 PM" src="https://user-images.githubusercontent.com/25523682/58282982-324c0800-7d75-11e9-9652-d6cc91299ce4.png">
<img width="1279" alt="Screen Shot 2019-05-23 at 4 09 07 PM" src="https://user-images.githubusercontent.com/25523682/58282983-324c0800-7d75-11e9-8c63-57fd6934d300.png">
